### PR TITLE
Configure for Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM hseeberger/scala-sbt
+
+COPY build.sbt build.sbt
+
+COPY src src
+
+RUN sbt package
+
+CMD sbt run

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM hseeberger/scala-sbt
 
 COPY build.sbt build.sbt
 
-COPY src src
-
 RUN sbt package
+
+RUN sbt update
+
+COPY src src
 
 CMD sbt run

--- a/manifest.kubernetes
+++ b/manifest.kubernetes
@@ -1,0 +1,67 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: akka-master
+spec:
+  selector:
+    matchLabels:
+      app: akka-example # has to match .spec.template.metadata.labels
+      role: master
+  replicas: 1
+  serviceName: akka
+  template:
+    metadata:
+      labels:
+        app: akka-example
+        role: master
+    spec:
+      terminationGracePeriodSeconds: 3
+      containers:
+      - name: akka-example
+        image: adamsandor83/akka-example
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 2551
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: akka-worker
+spec:
+  selector:
+    matchLabels:
+      app: akka-example # has to match .spec.template.metadata.labels
+      role: worker
+  podManagementPolicy: Parallel
+  replicas: 3
+  serviceName: akka
+  template:
+    metadata:
+      labels:
+        app: akka-example
+        role: worker
+    spec:
+      terminationGracePeriodSeconds: 3
+      containers:
+      - name: akka-example
+        image: adamsandor83/akka-example
+        imagePullPolicy: Always
+        env:
+        - name: ROLE
+          value: worker
+        ports:
+        - containerPort: 2551
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: akka
+  labels:
+    app: akka-example
+spec:
+  ports:
+  - port: 2551
+    name: akka
+  clusterIP: None
+  selector:
+    app: akka-example

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -7,19 +7,21 @@ akka {
   remote {
     enabled-transports = ["akka.remote.netty.tcp"]
     netty.tcp {
-      hostname = "127.0.0.1"
+      hostname = ${HOSTNAME}.akka
       port = 2551
-      port = ${?PORT}
+
+      bind-hostname = ${HOSTNAME}
+      bind-port = 2551
     }
   }
 
   cluster {
 
     seed-nodes = [
-      "akka.tcp://akka-cluster-router-group@127.0.0.1:2551"
+      "akka.tcp://akka-cluster-router-group@akka-master-0.akka:2551",
+      "akka.tcp://akka-cluster-router-group@akka-worker-0.akka:2551"
     ]
     min-nr-of-members = 1
-    auto-down-unreachable-after = 30s
 
     roles = ["seed"]
     roles = ${?ROLES}


### PR DESCRIPTION
I used Kubernetes StatefulSets to create master and worker nodes with static domain names. This is a bit different then what we discussed last time. The reason simply using Deployment+Service wasn't enough is that each individual Pod needs to have their own domain name. Stateful set makes sure this happens. Pods will get hostnames like `akka-worker-0`, `akka-worker-1`, etc with corresponding DNS entries `akka-worker-0.akka`. To have the DNS entries it's necessary to have the Service at the end of the manifest file created. In the application.conf I configured both the external and internal hostname that the Akka clustering expects. One is the pure hostname the other is the DNS name.